### PR TITLE
suppress redirect when not on teams view

### DIFF
--- a/ui-src/src/flex-hooks/components/TaskOverviewCanvas.tsx
+++ b/ui-src/src/flex-hooks/components/TaskOverviewCanvas.tsx
@@ -19,8 +19,9 @@ export function addSupervisorBargeCoachButtons(flex: typeof Flex, manager: Flex.
     // We need to invoke an action to trigger this again, so it populates the stickyWorker for us
     const agentWorkerSID = manager.store.getState().flex?.supervisor?.stickyWorker?.worker?.sid;
     const teamViewTaskSID = localStorage.getItem('teamViewTaskSID');
+    const intendedRoute = window.document.location.pathname;
     // Check that the stickyWorker is null and that we are attempting to restore the last worker they monitored
-    if (agentWorkerSID == null && teamViewTaskSID != null) {
+    if (agentWorkerSID == null && teamViewTaskSID != null && intendedRoute.includes('/teams/')) {
       console.log(`teamViewSID = ${teamViewTaskSID}`);
 
       // Invoke action to trigger the monitor button so we can populate the stickyWorker attribute


### PR DESCRIPTION
The `SelectTaskInSupervisor` Action navigates to the teams view if that's not the active view already. We do this when `teamViewTaskSID` has been set in localStorage, but that value is never unset. So subsequent page loads in Flex UI will always default the view back to the Teams View. We should only trigger the action and stage the monitor config if we're running a page refresh.

The primary consequence for users today is that links they share with colleagues (or their own page refreshes) won't work. For example navigating to `flex.twilio.com/my-custom-route?p=thing-i-want-you-to-see` would still always load the Teams View.